### PR TITLE
Fix incorrect SQL table name in EnquiryDao.create() method

### DIFF
--- a/src/com/tnt/dao/EnquiryDao.java
+++ b/src/com/tnt/dao/EnquiryDao.java
@@ -22,14 +22,14 @@ public class EnquiryDao {
 	public int create(Enquiry e) throws Exception {
 		int i = 0;
 		try (Connection con = DBManager.getcon();) {
-			String sql = "INSERT INTO Issues( UserEmail , Issue , Description,) VALUES(?, ?, ?) ";
+			String sql = "INSERT INTO Enquiry( UserEmail , Issue , Description ) VALUES(?, ?, ?) ";
 			PreparedStatement ps = con.prepareStatement(sql);
-//			ps.setString(1, e.getUserEmail());
-//			ps.setString(2, e.getIssue());
+			ps.setString(1, e.getUserEmail());
+			ps.setString(2, e.getIssue());
 			ps.setString(3, e.getDescription());
 			i = ps.executeUpdate();
 			if (i > 0) {
-				System.out.println("A new Issue was inserted successfully!");
+				System.out.println("A new Enquiry was inserted successfully!");
 			}
 		} catch (Exception e1) {
 			e1.printStackTrace();


### PR DESCRIPTION
## Description
This PR fixes the incorrect SQL table name in the `EnquiryDao.create()` method as reported in issue #10.

## Changes Made
- **Fixed table name**: Changed from `Issues` to `Enquiry` in the INSERT statement (line 25)
- **Removed syntax error**: Removed extra comma in column list
- **Uncommented parameter setting**: Enabled proper parameter binding for `UserEmail` and `Issue` fields
- **Updated success message**: Changed from "Issue" to "Enquiry" for consistency

## Problem Fixed
The `EnquiryDao.create()` method was incorrectly inserting data into the `Issues` table instead of the `Enquiry` table, causing data integrity issues.

## Testing
- [x] Code compiles without syntax errors
- [x] SQL statement now correctly references the `Enquiry` table
- [x] All parameters are properly bound

## Related Issue
Fixes #10

## Priority
High - This fixes a data integrity issue that could cause data to be stored in the wrong table.